### PR TITLE
[EXE-628] Check Flame version and cross-compile scala2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ project/target
 .idea_modules/
 *.DS_Store
 build/*.jar
+.bsp
 *.private
 metastore_db/*
 *.log

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,9 @@
 
 import scala.util.Properties
 
-val sparkVersion = "2.4.0"
+val sparkVersion = "2.4.7"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
+val defaultScalaVersion = "2.12.15"
 
 /*
  * Don't change the variable name "sparkConnectorVersion" because
@@ -26,7 +27,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3"
+val sparkConnectorVersion = "2.9.3-aiq1"
 
 lazy val ItTest = config("it") extend Test
 
@@ -42,8 +43,8 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     name := "spark-snowflake",
     organization := "net.snowflake",
     version := s"${sparkConnectorVersion}-spark_2.4",
-    scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
-    crossScalaVersions := Seq("2.11.12", "2.12.11"),
+    scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = defaultScalaVersion),
+    crossScalaVersions := Seq("2.11.12", defaultScalaVersion),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -34,16 +34,16 @@ object SnowflakeConnectorUtils {
     * Check Spark version, if Spark version matches SUPPORT_SPARK_VERSION enable PushDown,
     * otherwise disable it.
     */
-  val SUPPORT_SPARK_VERSION = "2.4"
+  val SUPPORT_SPARK_VERSIONS = Seq("2.4", "2-4")
 
   def checkVersionAndEnablePushdown(session: SparkSession): Boolean =
-    if (session.version.startsWith(SUPPORT_SPARK_VERSION)) {
+    if (SUPPORT_SPARK_VERSIONS.exists(session.version.startsWith)) {
       enablePushdownSession(session)
       true
     } else {
       log.warn("Query pushdown is not supported because you are using " +
         s"Spark ${session.version} with a connector designed to support Spark " +
-        s"$SUPPORT_SPARK_VERSION. Either use the version of Spark supported by " +
+        s"$SUPPORT_SPARK_VERSIONS. Either use the version of Spark supported by " +
         s"the connector or install a version of the connector that supports " +
         s"your version of Spark.")
       disablePushdownSession(session)


### PR DESCRIPTION
Checking for Flame version (`2-4` vs `2.4`) and cross compiling for our scala versions (2.11.12, 2.12.15) to match AIQ repo.

### Test
```
sbt test
[info] Tests: succeeded 58, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 8 s, completed Feb 15, 2022 4:07:28 PM
```

### Deploy
```
# bump sparkConnectorVersion
sbt +publishM2
aws s3 sync ~/.m2/repository/net/snowflake/ s3://aiq-artifacts/releases/net/snowflake
``` 