### PR TITLE
[EXE-925] Lowercase JDBC_TREAT_DECIMAL_AS_INT session parameter

### DIFF
--- a/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
+++ b/ClusterTest/src/main/scala/net/snowflake/spark/snowflake/TestUtils.scala
@@ -225,7 +225,7 @@ object TestUtils {
     jdbcProperties.put("client_session_keep_alive", "true")
 
     // Force DECIMAL for NUMBER (SNOW-33227)
-    jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")
+    jdbcProperties.put("jdbc_treat_decimal_as_int", "false")
 
     // Add extra properties from sfOptions
     val extraOptions = params.sfExtraOptions

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val defaultScalaVersion = "2.12.15"
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3-aiq1"
+val sparkConnectorVersion = "2.9.3-aiq1-intDecimalParam"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val defaultScalaVersion = "2.12.15"
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3-aiq1-intDecimalParam"
+val sparkConnectorVersion = "2.9.3-aiq2"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -183,7 +183,7 @@ private[snowflake] class JDBCWrapper {
     jdbcProperties.put("client_session_keep_alive", "true")
 
     // Force DECIMAL for NUMBER (SNOW-33227)
-    jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")
+    jdbcProperties.put("jdbc_treat_decimal_as_int", "false")
 
     // Add extra properties from sfOptions
     val extraOptions = params.sfExtraOptions


### PR DESCRIPTION
[EXE-925](https://actioniq.atlassian.net/browse/EXE-925)

With `jdbcProperties.put("JDBC_TREAT_DECIMAL_AS_INT", "false")`, it's not possible to fully override the `JDBC_TREAT_DECIMAL_AS_INT` session parameter from the client since all input parameters [are lowercased](https://github.com/ActionIQ-OSS/spark-snowflake/compare/spark_2.4...ActionIQ-OSS:spark-snowflake:danielSomekhEnableJdbcTreatDecimalAsInt?expand=1#diff-2639e166fe55f13ff2e4fa6f0986aa4c2ce216bdfcd7b2a767e6bed4ead289d4R191). The [snowflake jdbc](https://github.com/snowflakedb/snowflake-jdbc/blob/bee8bb0da56e882820f4dde2f20580d404cffff1/src/main/java/net/snowflake/client/core/SessionUtil.java#L1392-L1392) eventually iterates over these parameters, so whichever parameter is chosen last (the upper cased or lower cased) will win.

By lowercasing the `JDBC_TREAT_DECIMAL_AS_INT` parameter for initialization, it's possible to repeatably override it.

### Test
Ran spark driver and passed in `jdbc_treat_decimal_as_int` as `true` and logged out the final value to see this get overridden.

### Deploy
```
rm -rf ~/.m2/repository/net/snowflake/
sbt clean
# bump sparkConnectorVersion
sbt +publishM2
aws s3 sync ~/.m2/repository/net/snowflake/ s3://aiq-artifacts/releases/net/snowflake
``` 