### PR TITLE
[EXE-1427] Add callstack logging to query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val defaultScalaVersion = "2.12.15"
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3-aiq2"
+val sparkConnectorVersion = "2.9.3-aiq3"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val defaultScalaVersion = "2.12.15"
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3-aiq3"
+val sparkConnectorVersion = "2.9.3-aiq4"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val defaultScalaVersion = "2.12.15"
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.9.3-aiq4"
+val sparkConnectorVersion = "2.9.3-aiq5"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -784,10 +784,19 @@ private[snowflake] class SnowflakeSQLStatement(
       }
       .toString()
 
-    val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-                       | execute query without bind variable:
-                       |""".stripMargin.filter(_ >= ' ')
-    log.info(s"$logPrefix $query")
+    if (log.isDebugEnabled) {
+      val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
+                         |execute query without bind variable: $query
+                         |
+                         |${Thread.currentThread.getStackTrace.map(_.toString).mkString("\n")}
+                         |""".stripMargin.filter(_ >= ' ')
+      log.info(logMsg)
+    } else {
+      val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
+                         | execute query without bind variable:
+                         |""".stripMargin.filter(_ >= ' ')
+      log.info(s"$logPrefix $query")
+    }
 
     conn.prepareStatement(query)
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -786,16 +786,19 @@ private[snowflake] class SnowflakeSQLStatement(
 
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-                         |execute query without bind variable: $query
+                         |execute query without bind variable =>
+                         |$query
                          |
-                         |${Thread.currentThread.getStackTrace.mkString("\n")}
-                         |""".stripMargin.filter(_ >= ' ')
-      log.info(logMsg)
+                         |callstack =>
+                         |${Thread.currentThread.getStackTrace.take(30).mkString("\n")}
+                         |""".stripMargin
+      log.debug(logMsg)
     } else {
-      val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-                         | execute query without bind variable:
-                         |""".stripMargin.filter(_ >= ' ')
-      log.info(s"$logPrefix $query")
+      val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
+                         |execute query without bind variable =>
+                         |$query
+                         |""".stripMargin
+      log.info(logMsg)
     }
 
     conn.prepareStatement(query)

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -788,7 +788,7 @@ private[snowflake] class SnowflakeSQLStatement(
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                          |execute query without bind variable: $query
                          |
-                         |${Thread.currentThread.getStackTrace.map(_.toString).mkString("\n")}
+                         |${Thread.currentThread.getStackTrace.mkString("\n")}
                          |""".stripMargin.filter(_ >= ' ')
       log.info(logMsg)
     } else {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -786,18 +786,18 @@ private[snowflake] class SnowflakeSQLStatement(
 
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-                         |execute query without bind variable =>
-                         |$query
-                         |
-                         |callstack =>
-                         |${Thread.currentThread.getStackTrace.take(30).mkString("\n")}
-                         |""".stripMargin
+         |execute query without bind variable =>
+         |$query
+         |
+         |callstack =>
+         |${Thread.currentThread.getStackTrace.take(30).mkString("\n")}
+         |""".stripMargin
       log.debug(logMsg)
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
-                         |execute query without bind variable =>
-                         |$query
-                         |""".stripMargin
+         |execute query without bind variable =>
+         |$query
+         |""".stripMargin
       log.info(logMsg)
     }
 


### PR DESCRIPTION
[EXE-1427]

Adding callstack logging to help debug why queries run twice

### Test
Built locally, used in spark shell
```
23/03/28 23:31:34 INFO SnowflakeRelation: Now executing below command to read from snowflake:
SELECT * FROM ( SELECT ( "SUBQUERY_1"."customer_id" ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE ( ( "SUBQUERY_0"."state" IS NOT NULL ) AND ( "SUBQUERY_0"."state" = 'NY' ) ) ) AS "SUBQUERY_1" ) AS "SUBQUERY_2" LIMIT 10
23/03/28 23:31:34 DEBUG SnowflakeSQLStatement: Spark Connector Master:
execute query without bind variable =>
SELECT * FROM ( SELECT ( "SUBQUERY_1"."customer_id" ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE ( ( "SUBQUERY_0"."state" IS NOT NULL ) AND ( "SUBQUERY_0"."state" = 'NY' ) ) ) AS "SUBQUERY_1" ) AS "SUBQUERY_2" LIMIT 10

callstack =>
java.lang.Thread.getStackTrace(Thread.java:1559)
net.snowflake.spark.snowflake.SnowflakeSQLStatement.parepareWithoutBindVariable(SnowflakeJDBCWrapper.scala:793)
net.snowflake.spark.snowflake.SnowflakeSQLStatement.prepareStatement(SnowflakeJDBCWrapper.scala:772)
net.snowflake.spark.snowflake.SnowflakeSQLStatement.executeAsync(SnowflakeJDBCWrapper.scala:755)
net.snowflake.spark.snowflake.SnowflakeRelation.liftedTree1$1(SnowflakeRelation.scala:201)
net.snowflake.spark.snowflake.SnowflakeRelation.getSnowflakeResultSetRDD(SnowflakeRelation.scala:190)
net.snowflake.spark.snowflake.SnowflakeRelation.getRDD(SnowflakeRelation.scala:157)
net.snowflake.spark.snowflake.SnowflakeRelation.buildScanFromSQL(SnowflakeRelation.scala:105)
net.snowflake.spark.snowflake.pushdowns.querygeneration.QueryBuilder.toRDD(QueryBuilder.scala:123)
net.snowflake.spark.snowflake.pushdowns.querygeneration.QueryBuilder.rdd$lzycompute(QueryBuilder.scala:48)
net.snowflake.spark.snowflake.pushdowns.querygeneration.QueryBuilder.rdd(QueryBuilder.scala:48)
net.snowflake.spark.snowflake.pushdowns.querygeneration.QueryBuilder$.$anonfun$getRDDFromPlan$1(QueryBuilder.
```

### Deploy
```
rm -rf ~/.m2/repository/net/snowflake/
sbt clean
# bump sparkConnectorVersion
sbt +publishM2
aws s3 sync ~/.m2/repository/net/snowflake/ s3://aiq-artifacts/releases/net/snowflake
``` 